### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -114,6 +114,7 @@ You should also create the file `local.properties` in the `android` folder of th
 ```
 ndk.dir=/path/to/your/android/sdk/ndk/21.4.7075529
 ```
+set the environment variable NDK_PLATFORM to "android-21" in the shell rc file. 
 
 Add your debug keystore information to the `~/.gradle/gradle.properties` file.
 


### PR DESCRIPTION
Hello, sodium-native-nodejs-mobile has a problem that it does not pick up the NDK_PLATFORM in the script android-build.sh, so the build fails with  Building for platform [android-16]

WARNING:__main__:make_standalone_toolchain.py is no longer necessary. The $NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin directory contains target-specific scripts that perform the same task. For example, instead of:

    $ python $NDK/build/tools/make_standalone_toolchain.py \
        --arch arm --api 16 --install-dir toolchain
    $ toolchain/bin/clang++ src.cpp

Instead use:

    $ $NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi16-clang++ src.cpp

16 is less than minimum platform for arm (19)
/Users/kuntalsampat/proj/peanutt/nodejs-assets/nodejs-project/node_modules/sodium-native-nodejs-mobile/preinstall.js:175
      if (err) throw err
               ^

Error: ./dist-build/android-armv7-a.sh exited with 1.

By setting NDK_PLATFORM explicitly, the build succeeds.