### PR TITLE
Adds no-select and arrow cursor to topBar view

### DIFF
--- a/src/frontend/screens/central/top-bar/view.ts
+++ b/src/frontend/screens/central/top-bar/view.ts
@@ -190,6 +190,15 @@ export const styles = StyleSheet.create({
       'user-select': 'none',
     },
   }) as ViewStyle,
+  
+  
+  topBar: Platform.select({
+    web: {
+      'user-select': 'none',
+      'cursor': 'default'
+    },
+  }) as ViewStyle,
+
 });
 
 function tabTitle(tab: State['currentTab']) {


### PR DESCRIPTION
When dragging the window by the titlebar text, sometimes the text can become selected. The text also causes a text-cursor behavior on mouseover. This commit uses 2 css properties, cursor and user-select to remove these behaviors.